### PR TITLE
Add a bundle for Dask

### DIFF
--- a/Golden_Repo/2018b/d/Dask/Dask-Nov2018Bundle-ipsmpi-2018b-Python-2.7.15.eb
+++ b/Golden_Repo/2018b/d/Dask/Dask-Nov2018Bundle-ipsmpi-2018b-Python-2.7.15.eb
@@ -1,0 +1,116 @@
+easyblock = 'PythonBundle'
+
+name = 'Dask'
+version = 'Nov2018Bundle'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://github.com/dask/dask/'
+description = """Dask provides multi-core execution on larger-than-memory datasets using blocked algorithms
+ and task scheduling. This bundle includes dask-distributed and dask-jobqueue."""
+
+site_contacts = 'sc@fz-juelich.de'
+
+toolchain = {'name': 'ipsmpi', 'version': '2018b'}
+
+dependencies = [
+    ('Python', '2.7.15'),
+    ('mpi4py', '3.0.0', versionsuffix),
+    ('SciPy-Stack', '2018b', versionsuffix, ('gcccoremkl', '7.3.0-2019.0.117')),
+    ('Graphviz', '2.40.1'), # for dask
+    # Below is for Pillow
+    ('libjpeg-turbo', '1.5.3'),
+    ('libpng', '1.6.35'),
+    ('zlib', '1.2.11'),
+    ('LibTIFF', '4.0.9'),
+    ('freetype', '2.9.1')
+]
+
+exts_list = [
+    ('toolz', '0.9.0', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/t/toolz']),
+    ])),
+    ('dask', '0.20.0', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/d/dask']),
+    ])),
+    ('HeapDict', '1.0.0', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/h/heapdict']),
+           ('modulename', 'heapdict'),
+    ])),
+    ('zict', '0.1.3', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/z/zict']),
+    ])),
+    ('tblib', '1.3.2', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/t/tblib']),
+    ])),
+    ('sortedcontainers', '2.0.5', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/s/sortedcontainers']),
+    ])),
+    ('psutil', '5.4.8', dict([
+           ('prebuildopts', 'LDSHARED="icc -shared" '),
+           ('source_urls', ['https://pypi.python.org/packages/source/p/psutil']),
+    ])),
+    ('msgpack', '0.5.6', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/m/msgpack']),
+    ])),
+    ('cloudpickle', '0.6.1', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/c/cloudpickle']),
+    ])),
+    ('backports_abc', '0.5', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/b/backports_abc']),
+    ])),
+    ('singledispatch', '3.4.0.3', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/s/singledispatch']),
+    ])),
+    ('futures', '3.2.0', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/f/futures']),
+           ('modulename', 'concurrent.futures'),
+    ])),
+    ('tornado', '5.1.1', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/t/tornado']),
+    ])),
+    ('locket', '0.2.0', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/l/locket']),
+    ])),
+    ('Click', '7.0', dict([ 
+           ('source_urls', ['https://pypi.python.org/packages/source/c/click']),
+    ])),
+    ('Jinja2', '2.10', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/J/Jinja2']),
+    ])),
+    ('requests', '2.20.1', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/r/requests']),
+    ])),
+    ('Pillow', '5.3.0', dict([
+           ('prebuildopts', 'LDSHARED="icc -shared" '),
+           ('source_urls', ['https://pypi.python.org/packages/source/p/Pillow']),
+           ('modulename', 'PIL'),
+    ])),
+    ('bokeh', '1.0.1', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/b/bokeh']),
+    ])),
+    ('distributed', '1.24.0', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/d/distributed']),
+    ])),
+    ('graphviz', '0.10.1', dict([
+           ('source_tmpl', '%(name)s-%(version)s.zip'),
+           ('source_urls', ['https://pypi.python.org/packages/source/g/graphviz']),
+    ])),
+    ('docrep', '0.2.4', dict([ 
+           ('source_urls', ['https://pypi.python.org/packages/source/d/docrep']),
+    ])),
+    ('dask-jobqueue', '0.4.1', dict([ 
+           ('source_tmpl', '%(version)s.tar.gz'),
+           ('source_urls', ['https://github.com/dask/%(name)s/archive']),
+           ('modulename', 'dask_jobqueue'),
+    ])) 
+]
+
+
+sanity_check_paths = {
+    'files': ['bin/dask-mpi', 'bin/dask-scheduler', 'bin/dask-worker'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+full_sanity_check = True
+
+moduleclass = 'data'

--- a/Golden_Repo/2018b/d/Dask/Dask-Nov2018Bundle-ipsmpi-2018b-Python-3.6.6.eb
+++ b/Golden_Repo/2018b/d/Dask/Dask-Nov2018Bundle-ipsmpi-2018b-Python-3.6.6.eb
@@ -1,0 +1,109 @@
+easyblock = 'PythonBundle'
+
+name = 'Dask'
+version = 'Nov2018Bundle'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://github.com/dask/dask/'
+description = """Dask provides multi-core execution on larger-than-memory datasets using blocked algorithms
+ and task scheduling. This bundle includes dask-distributed and dask-jobqueue."""
+
+site_contacts = 'sc@fz-juelich.de'
+
+toolchain = {'name': 'ipsmpi', 'version': '2018b'}
+
+dependencies = [
+    ('Python', '3.6.6'),
+    ('mpi4py', '3.0.0', versionsuffix),
+    ('SciPy-Stack', '2018b', versionsuffix, ('gcccoremkl', '7.3.0-2019.0.117')),
+    ('Graphviz', '2.40.1'), # for dask
+    # Below is for Pillow
+    ('libjpeg-turbo', '1.5.3'),
+    ('libpng', '1.6.35'),
+    ('zlib', '1.2.11'),
+    ('LibTIFF', '4.0.9'),
+    ('freetype', '2.9.1')
+]
+
+exts_list = [
+    ('toolz', '0.9.0', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/t/toolz']),
+    ])),
+    ('dask', '0.20.0', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/d/dask']),
+    ])),
+    ('HeapDict', '1.0.0', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/h/heapdict']),
+           ('modulename', 'heapdict'),
+    ])),
+    ('zict', '0.1.3', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/z/zict']),
+    ])),
+    ('tblib', '1.3.2', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/t/tblib']),
+    ])),
+    ('sortedcontainers', '2.0.5', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/s/sortedcontainers']),
+    ])),
+    ('psutil', '5.4.8', dict([
+           ('prebuildopts', 'LDSHARED="icc -shared" '),
+           ('source_urls', ['https://pypi.python.org/packages/source/p/psutil']),
+    ])),
+    ('msgpack', '0.5.6', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/m/msgpack']),
+    ])),
+    ('cloudpickle', '0.6.1', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/c/cloudpickle']),
+    ])),
+    ('singledispatch', '3.4.0.3', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/s/singledispatch']),
+    ])),
+    ('tornado', '5.1.1', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/t/tornado']),
+    ])),
+    ('locket', '0.2.0', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/l/locket']),
+    ])),
+    ('Click', '7.0', dict([ 
+           ('source_urls', ['https://pypi.python.org/packages/source/c/click']),
+    ])),
+    ('Jinja2', '2.10', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/J/Jinja2']),
+    ])),
+    ('requests', '2.20.1', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/r/requests']),
+    ])),
+    ('Pillow', '5.3.0', dict([
+           ('prebuildopts', 'LDSHARED="icc -shared" '),
+           ('source_urls', ['https://pypi.python.org/packages/source/p/Pillow']),
+           ('modulename', 'PIL'),
+    ])),
+    ('bokeh', '1.0.1', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/b/bokeh']),
+    ])),
+    ('distributed', '1.24.0', dict([
+           ('source_urls', ['https://pypi.python.org/packages/source/d/distributed']),
+    ])),
+    ('graphviz', '0.10.1', dict([
+           ('source_tmpl', '%(name)s-%(version)s.zip'),
+           ('source_urls', ['https://pypi.python.org/packages/source/g/graphviz']),
+    ])),
+    ('docrep', '0.2.4', dict([ 
+           ('source_urls', ['https://pypi.python.org/packages/source/d/docrep']),
+    ])),
+    ('dask-jobqueue', '0.4.1', dict([ 
+           ('source_tmpl', '%(version)s.tar.gz'),
+           ('source_urls', ['https://github.com/dask/%(name)s/archive']),
+           ('modulename', 'dask_jobqueue'),
+    ])) 
+]
+
+
+sanity_check_paths = {
+    'files': ['bin/dask-mpi', 'bin/dask-scheduler', 'bin/dask-worker'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+full_sanity_check = True
+
+moduleclass = 'data'


### PR DESCRIPTION
This makes Dask and some of the subprojects available as a bundle, in particular `dask-distributed` and `dask-jobqueue`.